### PR TITLE
Make protobuf optional (default on)

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -13,7 +13,7 @@ env:
   VCPKG_COMMIT_ID: 'ad25766aefb5313b6bc4e2a4b78a2946f84fbf66'
 
 jobs:
-  job:
+  build_and_test:
     name: ${{ matrix.os }}-${{ github.workflow }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -22,19 +22,16 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         include:
           - os: windows-latest
-            vcpkgCommitId: 'ad25766aefb5313b6bc4e2a4b78a2946f84fbf66'
             cmake_preset: msvc22
-            extra_args: -D ZQ_WITH_PROTO=ON
+            extra_args: -D ZQ_WITH_PROTO=OFF
             # there was this odd error that could not be reproduced locally on Windos 10 or 11
             #  -> Running cpp protocol buffer compiler on D:/a/zq/zq/proto/pingpong.proto
             # The system cannot find the batch label specified - VCEnd
             # error MSB8066
             # need to look into it extra ,but for now, disable proto on Windows
           - os: ubuntu-latest
-            vcpkgCommitId: 'ad25766aefb5313b6bc4e2a4b78a2946f84fbf66'
             cmake_preset: ninja
           - os: macos-latest
-            vcpkgCommitId: 'ad25766aefb5313b6bc4e2a4b78a2946f84fbf66'
             cmake_preset: xcode
 
     steps:
@@ -57,27 +54,23 @@ jobs:
           ninjaVersion: "^1.12.0"  # <--= optional, use most recent 1.x version
 
       # it's not good to not test proto on Windows, but that accelerates the build for Windows
-      # - name: Remove protobuf from vcpkg.json on Windows
-      #   run: |
-      #     (Get-Content -path vcpkg.json) | Where-Object { $_ -notmatch '^\s*"protobuf",\s*$' } | Set-Content -Path vcpkg.json
-      #   shell: pwsh
-      #   if: matrix.os == 'windows-latest'
+      - name: Remove protobuf from vcpkg.json on Windows
+        run: |
+          (Get-Content -path vcpkg.json) | Where-Object { $_ -notmatch '^\s*"protobuf",\s*$' } | Set-Content -Path vcpkg.json
+        shell: pwsh
+        if: matrix.os == 'windows-latest'
 
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11
         id: runvcpkg
         with:
-          # This specifies the location of vcpkg, where it is going to be restored from cache, or create from scratch.
           vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
-          # The Git commit id of vcpkg to be checked out. This is only needed because we are not using a submodule.
           vcpkgGitCommitId: '${{ env.VCPKG_COMMIT_ID }}'
-          # The vcpkg.json file, which will be part of cache key computation.
           vcpkgJsonGlob: 'vcpkg.json'
 
       - name: Configure CMake
         run: |
-          cmake --preset ${{ matrix.cmake_preset }}
-#          cmake --preset ${{ matrix.cmake_preset }} ${{ matrix.extra_args }}
+          cmake --preset ${{ matrix.cmake_preset }} ${{ matrix.extra_args }}
 
       - name: Build
         run: |

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -72,6 +72,8 @@ jobs:
       #   run: echo "root='${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}', triplet='${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_DEFAULT_TRIPLET_OUT }}'"
 
       - name: Configure CMake
+        env:
+          VCPKG_ROOT: ${{ env.VCPKG_INSTALLATION_ROOT }}
         run: |
           cmake --preset ${{ matrix.cmake_preset }}
 

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -22,6 +22,11 @@ jobs:
             vcpkgCommitId: '6e31ee33cc9fc93599c4ceb38e229098cf339bb7'
             cmake_preset: msvc22
             extra_args: -D ZQ_WITH_PROTO=OFF
+            # there was this odd error that could not be reproduced locally on Windos 10 or 11
+            #  -> Running cpp protocol buffer compiler on D:/a/zq/zq/proto/pingpong.proto
+            # The system cannot find the batch label specified - VCEnd
+            # error MSB8066
+            # need to look into it extra ,but for now, disable proto on Windows
           - os: ubuntu-latest
             vcpkgCommitId: '6e31ee33cc9fc93599c4ceb38e229098cf339bb7'
             cmake_preset: ninja
@@ -48,12 +53,12 @@ jobs:
           cmakeVersion: "~3.28.0"  # <--= optional, use most recent 3.25.x version
           ninjaVersion: "^1.12.0"  # <--= optional, use most recent 1.x version
 
-      # - name: Dump the content of $RUNNER_TEMP
-      #   run: find $RUNNER_TEMP
-      #   shell: bash
-      # - name: Dump the content of $RUNNER_WORKSPACE
-      #   run: find $RUNNER_WORKSPACE
-      #   shell: bash
+      # it's not good to not test proto on Windows, but that accelerates the build for Windows
+      - name: Remove protobuf from vcpkg.json on Windows
+        run: |
+          (Get-Content -path vcpkg.json) | Where-Object { $_ -notmatch '^\s*"protobuf",\s*$' } | Set-Content -Path vcpkg.json
+        shell: pwsh
+        if: matrix.os == 'windows-latest'
 
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11
@@ -65,9 +70,6 @@ jobs:
           vcpkgGitCommitId: '${{ matrix.vcpkgCommitId}}'
           # The vcpkg.json file, which will be part of cache key computation.
           vcpkgJsonGlob: 'vcpkg.json'
-
-      # - name: Prints output of run-vcpkg's action
-      #   run: echo "root='${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}', triplet='${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_DEFAULT_TRIPLET_OUT }}'"
 
       - name: Configure CMake
         run: |

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -79,3 +79,9 @@ jobs:
       - name: Test
         run: |
           ctest --preset ${{ matrix.cmake_preset }} --output-on-failure
+
+
+  coverage:
+    uses: ./.github/workflows/build-coverage.yml
+
+

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -21,6 +21,7 @@ jobs:
           - os: windows-latest
             vcpkgCommitId: '6e31ee33cc9fc93599c4ceb38e229098cf339bb7'
             cmake_preset: msvc22
+            extra_args: -D ZQ_WITH_PROTO=OFF
           - os: ubuntu-latest
             vcpkgCommitId: '6e31ee33cc9fc93599c4ceb38e229098cf339bb7'
             cmake_preset: ninja
@@ -70,11 +71,11 @@ jobs:
 
       - name: Configure CMake
         run: |
-          cmake --preset ${{ matrix.cmake_preset }}
+          cmake --preset ${{ matrix.cmake_preset }}  ${{ matrix.extra_args }}
 
       - name: Build
         run: |
-          cmake --build --preset ${{ matrix.cmake_preset }}
+          cmake --build --preset ${{ matrix.cmake_preset }} --verbose
 
       - name: Test
         run: |

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -31,6 +31,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set VCPKG_ROOT
+        run: echo "VCPKG_ROOT=${{ env.VCPKG_INSTALLATION_ROOT }}" >> $GITHUB_ENV
+
       - name: Install dependencies on Ubuntu
         if: matrix.os == 'ubuntu-latest'
         run: |

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -19,13 +19,13 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         include:
           - os: windows-latest
-            vcpkgCommitId: '5fa0f075ea51f305b627ecd5e050a363707353ff'
+            vcpkgCommitId: '6e31ee33cc9fc93599c4ceb38e229098cf339bb7'
             cmake_preset: msvc22
           - os: ubuntu-latest
-            vcpkgCommitId: '5fa0f075ea51f305b627ecd5e050a363707353ff'
+            vcpkgCommitId: '6e31ee33cc9fc93599c4ceb38e229098cf339bb7'
             cmake_preset: ninja
           - os: macos-latest
-            vcpkgCommitId: '5fa0f075ea51f305b627ecd5e050a363707353ff'
+            vcpkgCommitId: '6e31ee33cc9fc93599c4ceb38e229098cf339bb7'
             cmake_preset: xcode
 
     steps:
@@ -35,7 +35,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake ninja-build libtool autoconf automake lcov
+          sudo apt-get install -y cmake libtool autoconf automake lcov
 
       - name: Install dependencies on Mac
         if: matrix.os == 'macos-latest'
@@ -43,6 +43,10 @@ jobs:
           brew install lcov autoconf automake libtool
 
       - uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: "~3.28.0"  # <--= optional, use most recent 3.25.x version
+          ninjaVersion: "^1.12.0"  # <--= optional, use most recent 1.x version
+
       - name: Dump the content of $RUNNER_TEMP
         run: find $RUNNER_TEMP
         shell: bash
@@ -57,7 +61,7 @@ jobs:
           # This specifies the location of vcpkg, where it is going to be restored from cache, or create from scratch.
           vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
           # The Git commit id of vcpkg to be checked out. This is only needed because we are not using a submodule.
-          vcpkgGitCommitId: '${{ matrix.vcpkgCommitId}}'
+          vcpkgGitCommitId: '${{ matrix.vcpkgCommitId}}x'
           # The vcpkg.json file, which will be part of cache key computation.
           vcpkgJsonGlob: 'vcpkg.json'
 

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -61,7 +61,7 @@ jobs:
           # This specifies the location of vcpkg, where it is going to be restored from cache, or create from scratch.
           vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
           # The Git commit id of vcpkg to be checked out. This is only needed because we are not using a submodule.
-          vcpkgGitCommitId: '${{ matrix.vcpkgCommitId}}x'
+          vcpkgGitCommitId: '${{ matrix.vcpkgCommitId}}'
           # The vcpkg.json file, which will be part of cache key computation.
           vcpkgJsonGlob: 'vcpkg.json'
 

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -55,7 +55,7 @@ jobs:
         shell: bash
 
       - name: Setup vcpkg
-        uses: lukka/run-vcpkg@main
+        uses: lukka/run-vcpkg@v11
         id: runvcpkg
         with:
           # This specifies the location of vcpkg, where it is going to be restored from cache, or create from scratch.

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -32,7 +32,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set VCPKG_ROOT
-        run: echo "VCPKG_ROOT=${{ env.VCPKG_INSTALLATION_ROOT }}" >> $GITHUB_ENV
+        shell: bash
+        run: echo "VCPKG_ROOT=${VCPKG_INSTALLATION_ROOT}" >> $GITHUB_ENV
+        if: runner.os != 'Windows'
+      - name: Set VCPKG_ROOT (Windows)
+        shell: pwsh
+        run: echo "VCPKG_ROOT=$(echo $env:VCPKG_INSTALLATION_ROOT)" | Out-File -Append -Encoding utf8 -FilePath $env:GITHUB_ENV
+        if: runner.os == 'Windows'
 
       - name: Install dependencies on Ubuntu
         if: matrix.os == 'ubuntu-latest'
@@ -72,8 +78,6 @@ jobs:
       #   run: echo "root='${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}', triplet='${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_DEFAULT_TRIPLET_OUT }}'"
 
       - name: Configure CMake
-        env:
-          VCPKG_ROOT: ${{ env.VCPKG_INSTALLATION_ROOT }}
         run: |
           cmake --preset ${{ matrix.cmake_preset }}
 

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -21,7 +21,7 @@ jobs:
           - os: windows-latest
             vcpkgCommitId: '6e31ee33cc9fc93599c4ceb38e229098cf339bb7'
             cmake_preset: msvc22
-            extra_args: -D ZQ_WITH_PROTO=OFF
+            extra_args: -D ZQ_WITH_PROTO=ON
             # there was this odd error that could not be reproduced locally on Windos 10 or 11
             #  -> Running cpp protocol buffer compiler on D:/a/zq/zq/proto/pingpong.proto
             # The system cannot find the batch label specified - VCEnd
@@ -41,7 +41,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake libtool autoconf automake lcov
+          sudo apt-get install -y libtool autoconf automake lcov
 
       - name: Install dependencies on Mac
         if: matrix.os == 'macos-latest'
@@ -54,11 +54,11 @@ jobs:
           ninjaVersion: "^1.12.0"  # <--= optional, use most recent 1.x version
 
       # it's not good to not test proto on Windows, but that accelerates the build for Windows
-      - name: Remove protobuf from vcpkg.json on Windows
-        run: |
-          (Get-Content -path vcpkg.json) | Where-Object { $_ -notmatch '^\s*"protobuf",\s*$' } | Set-Content -Path vcpkg.json
-        shell: pwsh
-        if: matrix.os == 'windows-latest'
+      # - name: Remove protobuf from vcpkg.json on Windows
+      #   run: |
+      #     (Get-Content -path vcpkg.json) | Where-Object { $_ -notmatch '^\s*"protobuf",\s*$' } | Set-Content -Path vcpkg.json
+      #   shell: pwsh
+      #   if: matrix.os == 'windows-latest'
 
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11
@@ -73,7 +73,8 @@ jobs:
 
       - name: Configure CMake
         run: |
-          cmake --preset ${{ matrix.cmake_preset }}  ${{ matrix.extra_args }}
+          cmake --preset ${{ matrix.cmake_preset }}
+#          cmake --preset ${{ matrix.cmake_preset }} ${{ matrix.extra_args }}
 
       - name: Build
         run: |

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -9,6 +9,9 @@ on:
       - main
   workflow_dispatch:
 
+env:
+  VCPKG_COMMIT_ID: 'ad25766aefb5313b6bc4e2a4b78a2946f84fbf66'
+
 jobs:
   job:
     name: ${{ matrix.os }}-${{ github.workflow }}
@@ -19,7 +22,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         include:
           - os: windows-latest
-            vcpkgCommitId: '6e31ee33cc9fc93599c4ceb38e229098cf339bb7'
+            vcpkgCommitId: 'ad25766aefb5313b6bc4e2a4b78a2946f84fbf66'
             cmake_preset: msvc22
             extra_args: -D ZQ_WITH_PROTO=ON
             # there was this odd error that could not be reproduced locally on Windos 10 or 11
@@ -28,10 +31,10 @@ jobs:
             # error MSB8066
             # need to look into it extra ,but for now, disable proto on Windows
           - os: ubuntu-latest
-            vcpkgCommitId: '6e31ee33cc9fc93599c4ceb38e229098cf339bb7'
+            vcpkgCommitId: 'ad25766aefb5313b6bc4e2a4b78a2946f84fbf66'
             cmake_preset: ninja
           - os: macos-latest
-            vcpkgCommitId: '6e31ee33cc9fc93599c4ceb38e229098cf339bb7'
+            vcpkgCommitId: 'ad25766aefb5313b6bc4e2a4b78a2946f84fbf66'
             cmake_preset: xcode
 
     steps:
@@ -67,7 +70,7 @@ jobs:
           # This specifies the location of vcpkg, where it is going to be restored from cache, or create from scratch.
           vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
           # The Git commit id of vcpkg to be checked out. This is only needed because we are not using a submodule.
-          vcpkgGitCommitId: '${{ matrix.vcpkgCommitId}}'
+          vcpkgGitCommitId: '${{ env.VCPKG_COMMIT_ID }}'
           # The vcpkg.json file, which will be part of cache key computation.
           vcpkgJsonGlob: 'vcpkg.json'
 

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -29,7 +29,7 @@ jobs:
             cmake_preset: xcode
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install dependencies on Ubuntu
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -31,15 +31,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set VCPKG_ROOT
-        shell: bash
-        run: echo "VCPKG_ROOT=${VCPKG_INSTALLATION_ROOT}" >> $GITHUB_ENV
-        if: runner.os != 'Windows'
-      - name: Set VCPKG_ROOT (Windows)
-        shell: pwsh
-        run: echo "VCPKG_ROOT=$(echo $env:VCPKG_INSTALLATION_ROOT)" | Out-File -Append -Encoding utf8 -FilePath $env:GITHUB_ENV
-        if: runner.os == 'Windows'
-
       - name: Install dependencies on Ubuntu
         if: matrix.os == 'ubuntu-latest'
         run: |
@@ -63,16 +54,16 @@ jobs:
       #   run: find $RUNNER_WORKSPACE
       #   shell: bash
 
-      # - name: Setup vcpkg
-      #   uses: lukka/run-vcpkg@v11
-      #   id: runvcpkg
-      #   with:
-      #     # This specifies the location of vcpkg, where it is going to be restored from cache, or create from scratch.
-      #     vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
-      #     # The Git commit id of vcpkg to be checked out. This is only needed because we are not using a submodule.
-      #     vcpkgGitCommitId: '${{ matrix.vcpkgCommitId}}'
-      #     # The vcpkg.json file, which will be part of cache key computation.
-      #     vcpkgJsonGlob: 'vcpkg.json'
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@v11
+        id: runvcpkg
+        with:
+          # This specifies the location of vcpkg, where it is going to be restored from cache, or create from scratch.
+          vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
+          # The Git commit id of vcpkg to be checked out. This is only needed because we are not using a submodule.
+          vcpkgGitCommitId: '${{ matrix.vcpkgCommitId}}'
+          # The vcpkg.json file, which will be part of cache key computation.
+          vcpkgJsonGlob: 'vcpkg.json'
 
       # - name: Prints output of run-vcpkg's action
       #   run: echo "root='${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}', triplet='${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_DEFAULT_TRIPLET_OUT }}'"

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -47,26 +47,26 @@ jobs:
           cmakeVersion: "~3.28.0"  # <--= optional, use most recent 3.25.x version
           ninjaVersion: "^1.12.0"  # <--= optional, use most recent 1.x version
 
-      - name: Dump the content of $RUNNER_TEMP
-        run: find $RUNNER_TEMP
-        shell: bash
-      - name: Dump the content of $RUNNER_WORKSPACE
-        run: find $RUNNER_WORKSPACE
-        shell: bash
+      # - name: Dump the content of $RUNNER_TEMP
+      #   run: find $RUNNER_TEMP
+      #   shell: bash
+      # - name: Dump the content of $RUNNER_WORKSPACE
+      #   run: find $RUNNER_WORKSPACE
+      #   shell: bash
 
-      - name: Setup vcpkg
-        uses: lukka/run-vcpkg@v11
-        id: runvcpkg
-        with:
-          # This specifies the location of vcpkg, where it is going to be restored from cache, or create from scratch.
-          vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
-          # The Git commit id of vcpkg to be checked out. This is only needed because we are not using a submodule.
-          vcpkgGitCommitId: '${{ matrix.vcpkgCommitId}}'
-          # The vcpkg.json file, which will be part of cache key computation.
-          vcpkgJsonGlob: 'vcpkg.json'
+      # - name: Setup vcpkg
+      #   uses: lukka/run-vcpkg@v11
+      #   id: runvcpkg
+      #   with:
+      #     # This specifies the location of vcpkg, where it is going to be restored from cache, or create from scratch.
+      #     vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
+      #     # The Git commit id of vcpkg to be checked out. This is only needed because we are not using a submodule.
+      #     vcpkgGitCommitId: '${{ matrix.vcpkgCommitId}}'
+      #     # The vcpkg.json file, which will be part of cache key computation.
+      #     vcpkgJsonGlob: 'vcpkg.json'
 
-      - name: Prints output of run-vcpkg's action
-        run: echo "root='${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}', triplet='${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_DEFAULT_TRIPLET_OUT }}'"
+      # - name: Prints output of run-vcpkg's action
+      #   run: echo "root='${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}', triplet='${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_DEFAULT_TRIPLET_OUT }}'"
 
       - name: Configure CMake
         run: |

--- a/.github/workflows/build-coverage.yml
+++ b/.github/workflows/build-coverage.yml
@@ -1,13 +1,16 @@
 name: CMake Build Coverage
 
+# on:
+#   push:
+#     branches:
+#       - main
+#   pull_request:
+#     branches:
+#       - main
+#   workflow_dispatch:
+
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
-  workflow_dispatch:
+  workflow_call:
 
 env:
   VCPKG_COMMIT_ID: 'ad25766aefb5313b6bc4e2a4b78a2946f84fbf66'

--- a/.github/workflows/build-coverage.yml
+++ b/.github/workflows/build-coverage.yml
@@ -32,14 +32,18 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake ninja-build lcov
+          sudo apt-get install -y cmake lcov
 
       - name: Install dependencies on Mac
         if: matrix.os == 'macos-latest'
         run: |
-          brew install ninja lcov autoconf automake libtool
+          brew install lcov autoconf automake libtool
 
       - uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: "~3.28.0"  # <--= optional, use most recent 3.25.x version
+          ninjaVersion: "^1.12.0"  # <--= optional, use most recent 1.x version
+
       - name: Dump the content of $RUNNER_TEMP
         run: find $RUNNER_TEMP
         shell: bash

--- a/.github/workflows/build-coverage.yml
+++ b/.github/workflows/build-coverage.yml
@@ -19,10 +19,10 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         include:
           - os: ubuntu-latest
-            vcpkgCommitId: '5fa0f075ea51f305b627ecd5e050a363707353ff'
+            vcpkgCommitId: '6e31ee33cc9fc93599c4ceb38e229098cf339bb7'
             cmake_preset: ninja
           - os: macos-latest
-            vcpkgCommitId: '5fa0f075ea51f305b627ecd5e050a363707353ff'
+            vcpkgCommitId: '6e31ee33cc9fc93599c4ceb38e229098cf339bb7'
             cmake_preset: ninja
 
     steps:

--- a/.github/workflows/build-coverage.yml
+++ b/.github/workflows/build-coverage.yml
@@ -52,7 +52,7 @@ jobs:
         shell: bash
 
       - name: Setup vcpkg
-        uses: lukka/run-vcpkg@main
+        uses: lukka/run-vcpkg@v11
         id: runvcpkg
         with:
           # This specifies the location of vcpkg, where it is going to be restored from cache, or create from scratch.

--- a/.github/workflows/build-coverage.yml
+++ b/.github/workflows/build-coverage.yml
@@ -26,7 +26,7 @@ jobs:
             cmake_preset: ninja
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install dependencies on Ubuntu
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/build-coverage.yml
+++ b/.github/workflows/build-coverage.yml
@@ -9,8 +9,11 @@ on:
       - main
   workflow_dispatch:
 
+env:
+  VCPKG_COMMIT_ID: 'ad25766aefb5313b6bc4e2a4b78a2946f84fbf66'
+
 jobs:
-  job:
+  coverage:
     name: ${{ matrix.os }}-${{ github.workflow }}-converage
     runs-on: ${{ matrix.os }}
     strategy:
@@ -19,10 +22,8 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         include:
           - os: ubuntu-latest
-            vcpkgCommitId: '6e31ee33cc9fc93599c4ceb38e229098cf339bb7'
             cmake_preset: ninja
           - os: macos-latest
-            vcpkgCommitId: '6e31ee33cc9fc93599c4ceb38e229098cf339bb7'
             cmake_preset: ninja
 
     steps:
@@ -55,11 +56,8 @@ jobs:
         uses: lukka/run-vcpkg@v11
         id: runvcpkg
         with:
-          # This specifies the location of vcpkg, where it is going to be restored from cache, or create from scratch.
           vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
-          # The Git commit id of vcpkg to be checked out. This is only needed because we are not using a submodule.
-          vcpkgGitCommitId: '${{ matrix.vcpkgCommitId}}'
-          # The vcpkg.json file, which will be part of cache key computation.
+          vcpkgGitCommitId: '${{ env.VCPKG_COMMIT_ID }}'
           vcpkgJsonGlob: 'vcpkg.json'
 
       - name: Prints output of run-vcpkg's action

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,8 @@ if(PROJECT_IS_TOP_LEVEL)
     )
 endif()
 
+option(ZQ_WITH_PROTO "Build with protobuf tests" ON)
+
 set(CMAKE_CXX_STANDARD 20)
 
 # Prepare for consumption of astr via vcpkg
@@ -60,6 +62,7 @@ target_sources(zq INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/zq/context.hpp>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/zq/error.hpp>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/zq/message.hpp>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/zq/message_proto.hpp> # doesnt matter to have the header if it's not used
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/zq/socket.hpp>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/zq/zflags.hpp>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/zq/zq.hpp>
@@ -69,17 +72,28 @@ target_include_directories(zq INTERFACE
     $<INSTALL_INTERFACE:include>
 )
 
-add_subdirectory(proto)
 
+if (ZQ_WITH_PROTO)
+    target_compile_definitions(zq INTERFACE "ZQ_PROTO")
+    add_subdirectory(proto)
+endif()
 
 target_link_libraries(zq
     INTERFACE
       libzmq
       tl::expected # until C++23
       fmt::fmt # until apple clang catches up
-      protobuf::libprotobuf
       a4z::astr
 )
+
+if (ZQ_WITH_PROTO)
+    target_link_libraries(zq
+        INTERFACE
+        protobuf::libprotobuf
+    )
+endif()
+
+
 
 include(GNUInstallDirs)
 install(TARGETS zq ${astrEXPORT} EXPORT zqTargets INCLUDES DESTINATION "${CMAKE_INSTALL_LIBDIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,8 +93,6 @@ if (ZQ_WITH_PROTO)
     )
 endif()
 
-
-
 include(GNUInstallDirs)
 install(TARGETS zq ${astrEXPORT} EXPORT zqTargets INCLUDES DESTINATION "${CMAKE_INSTALL_LIBDIR}")
 install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ target_include_directories(zq INTERFACE
 if (ZQ_WITH_PROTO)
     find_package(Protobuf CONFIG REQUIRED)
     target_compile_definitions(zq INTERFACE "ZQ_PROTO")
+    set(Protobuf_DEPENDENCY "find_dependency(Protobuf)")
     add_subdirectory(proto)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ find_package(astr CONFIG REQUIRED)
 find_package(ZeroMQ CONFIG REQUIRED)
 find_package(tl-expected CONFIG REQUIRED)
 find_package(fmt CONFIG REQUIRED) # until apple clang catches up
-find_package(Protobuf CONFIG REQUIRED)
+
 
 list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 include(setup_compiler)
@@ -74,6 +74,7 @@ target_include_directories(zq INTERFACE
 
 
 if (ZQ_WITH_PROTO)
+    find_package(Protobuf CONFIG REQUIRED)
     target_compile_definitions(zq INTERFACE "ZQ_PROTO")
     add_subdirectory(proto)
 endif()

--- a/cmake/testing.cmake
+++ b/cmake/testing.cmake
@@ -30,13 +30,10 @@ function (add_doctest NAME)
     add_executable(${NAME} ${D_TEST_SOURCES})
     target_link_libraries(${NAME} doctest_main)
 
-    # if(EXISTS ${PROJECT_SOURCE_DIR}/include)
-    #     target_include_directories(${NAME} BEFORE PRIVATE
-    #         ${PROJECT_SOURCE_DIR}/include
-    #     )
-    # endif()
-
-    target_link_libraries(${NAME} ${TEST_FRAMEWORK} zq zqproto zq_default::flags)
+    target_link_libraries(${NAME} ${TEST_FRAMEWORK} zq zq_default::flags)
+    if (ZQ_WITH_PROTO)
+        target_link_libraries(${NAME} zqproto)
+    endif()
 
     if(NOT D_TEST_TIMEOUT)
         set(D_TEST_TIMEOUT 3)

--- a/cmake/zqConfig.cmake.in
+++ b/cmake/zqConfig.cmake.in
@@ -2,6 +2,7 @@
 
 include("${CMAKE_CURRENT_LIST_DIR}/zqTargets.cmake")
 
+include(CMakeFindDependencyMacro)
 find_dependency(astr)
 find_dependency(Protobuf)
 find_dependency(tl-expected)

--- a/cmake/zqConfig.cmake.in
+++ b/cmake/zqConfig.cmake.in
@@ -2,4 +2,8 @@
 
 include("${CMAKE_CURRENT_LIST_DIR}/zqTargets.cmake")
 
+find_dependency(astr)
+find_dependency(Protobuf)
+find_dependency(tl-expected)
+
 check_required_components("zq")

--- a/cmake/zqConfig.cmake.in
+++ b/cmake/zqConfig.cmake.in
@@ -4,7 +4,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/zqTargets.cmake")
 
 include(CMakeFindDependencyMacro)
 find_dependency(astr)
-find_dependency(Protobuf)
+@Protobuf_DEPENDENCY@
 find_dependency(tl-expected)
 find_dependency(ZeroMQ)
 

--- a/cmake/zqConfig.cmake.in
+++ b/cmake/zqConfig.cmake.in
@@ -6,5 +6,6 @@ include(CMakeFindDependencyMacro)
 find_dependency(astr)
 find_dependency(Protobuf)
 find_dependency(tl-expected)
+find_dependency(ZeroMQ)
 
 check_required_components("zq")

--- a/include/zq/message.hpp
+++ b/include/zq/message.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <google/protobuf/message.h>
-
 #include <limits>
 
 #include "a4z/typename.hpp"
@@ -102,8 +100,6 @@ namespace zq {
   template <typename T>
   concept mem_copyable_message = mem_copyable<T> && !is_char_array<T>;
 
-  template <typename T>
-  concept protobuf_message = std::is_base_of_v<google::protobuf::Message, T>;
 
   // create type name message
   template <typename T>
@@ -132,16 +128,6 @@ namespace zq {
   {
     Message payload{sizeof(T)};
     std::memcpy(payload.data(), std::addressof(value), sizeof(T));
-    return TypedMessage(typename_message<T>(), std::move(payload));
-  }
-
-  template <typename T>
-  inline TypedMessage typed_message(const T& value)
-    requires std::is_base_of_v<google::protobuf::Message, T>
-  {
-    Message payload{value.ByteSizeLong()};
-    const auto msg_len = static_cast<int>(value.ByteSizeLong());
-    value.SerializeToArray(payload.data(), msg_len);
     return TypedMessage(typename_message<T>(), std::move(payload));
   }
 
@@ -180,36 +166,6 @@ namespace zq {
           std::runtime_error("Message type does not match"));
     }
     return as_string(msg.payload);
-  }
-
-  // This is a template specialization for restore_as function for types derived
-  // from google::protobuf::Message.
-  template <protobuf_message T>
-  inline auto restore_as(const TypedMessage& msg) noexcept
-      -> restore_result<T> {
-    auto check_type_name = [&]() {
-      constexpr auto tn = a4z::type_name<T>();
-      if (msg.type.size() != tn.size()) {
-        return false;
-      }
-      const auto expected_name = std::string_view(tn.c_str(), tn.size());
-      const auto having_name = as_string_view(msg.type);
-      return expected_name == having_name;
-    };
-
-    auto unexpected = [](std::string_view err_msg) {
-      return tl::make_unexpected(std::runtime_error(std::string{err_msg}));
-    };
-
-    if (!check_type_name()) {
-      return unexpected("Message type does not match");
-    }
-    T value;
-    auto proto_size = static_cast<int>(msg.payload.size());
-    if (!value.ParseFromArray(msg.payload.data(), proto_size)) {
-      return unexpected("Failed to parse protobuf");
-    }
-    return value;
   }
 
   // This is a template specialization for restore_as function for types that

--- a/include/zq/message_proto.hpp
+++ b/include/zq/message_proto.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <google/protobuf/message.h>
+#include "message.hpp"
+
+namespace zq {
+
+  template <typename T>
+  concept protobuf_message = std::is_base_of_v<google::protobuf::Message, T>;
+
+  template <typename T>
+  inline TypedMessage typed_message(const T& value)
+    requires std::is_base_of_v<google::protobuf::Message, T>
+  {
+    Message payload{value.ByteSizeLong()};
+    const auto msg_len = static_cast<int>(value.ByteSizeLong());
+    value.SerializeToArray(payload.data(), msg_len);
+    return TypedMessage(typename_message<T>(), std::move(payload));
+  }
+
+  // This is a template specialization for restore_as function for types derived
+  // from google::protobuf::Message.
+  template <protobuf_message T>
+  inline auto restore_as(const TypedMessage& msg) noexcept
+      -> restore_result<T> {
+    auto check_type_name = [&]() {
+      constexpr auto tn = a4z::type_name<T>();
+      if (msg.type.size() != tn.size()) {
+        return false;
+      }
+      const auto expected_name = std::string_view(tn.c_str(), tn.size());
+      const auto having_name = as_string_view(msg.type);
+      return expected_name == having_name;
+    };
+
+    auto unexpected = [](std::string_view err_msg) {
+      return tl::make_unexpected(std::runtime_error(std::string{err_msg}));
+    };
+
+    if (!check_type_name()) {
+      return unexpected("Message type does not match");
+    }
+    T value;
+    auto proto_size = static_cast<int>(msg.payload.size());
+    if (!value.ParseFromArray(msg.payload.data(), proto_size)) {
+      return unexpected("Failed to parse protobuf");
+    }
+    return value;
+  }
+
+
+}  // namespace zq

--- a/include/zq/zq.hpp
+++ b/include/zq/zq.hpp
@@ -3,5 +3,9 @@
 #include "context.hpp"
 
 #include "message.hpp"
+#ifdef ZQ_PROTO
+  #include "message_proto.hpp"
+#endif
+
 #include "socket.hpp"
 #include "zflags.hpp"

--- a/proto/CMakeLists.txt
+++ b/proto/CMakeLists.txt
@@ -1,7 +1,6 @@
 # Get the filenames of all the proto files.
 file(GLOB PROTO_FILES ${CMAKE_CURRENT_SOURCE_DIR}/*.proto)
 
-
 add_library(zqproto STATIC)
 
 MESSAGE(STATUS "Found protoc: ${Protobuf_PROTOC_EXECUTABLE}")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,14 @@ add_doctest(test-commu
     TIMEOUT 10
 )
 
+if (ZQ_WITH_PROTO)
+    target_sources(test-commu PRIVATE
+        commu/typedmessage_proto_test.cpp
+        commu/hello_proto_test.cpp
+    )
+endif()
+
+
 # keep that extra sice it takes sometiles so long in CI
 add_doctest(test-pubsub
     SOURCES
@@ -24,10 +32,12 @@ add_doctest(test-pubsub
     TIMEOUT 10
 )
 
-add_doctest(test-proto
-    SOURCES
-      proto/base.cpp
-)
+if (ZQ_WITH_PROTO)
+    add_doctest(test-proto
+        SOURCES
+        proto/base.cpp
+    )
+endif()
 
 add_doctest(test-ctx0
     SOURCES

--- a/tests/commu/hello_proto_test.cpp
+++ b/tests/commu/hello_proto_test.cpp
@@ -1,0 +1,65 @@
+#include <doctest/doctest.h>
+#include <zq/zq.hpp>
+#include <fmt/format.h>
+#include <chrono>
+#include <thread>
+#include "pingpong.pb.h"
+
+namespace {
+  // startup times on Windows are a problem, they take too long,
+  // this can cause test timeout
+  using namespace std::chrono_literals;
+  auto await_time = 1000ms;
+  // auto await_time = std::chrono::milliseconds(1000);
+}  // namespace
+
+
+SCENARIO("Make a hello world send receive call with proto messages") {
+  auto context = zq::mk_context();
+
+  GIVEN("a request and a reply socket with proto messages") {
+    // auto client = context->connect(zq::SocketType::REQ,
+    // "tcp://localhost:5555"); auto server = context->bind(zq::SocketType::REP,
+    // "tcp://localhost:5555");
+    auto client = context->connect(zq::SocketType::REQ, "ipc://localhost_5555");
+    auto server = context->bind(zq::SocketType::REP, "ipc://localhost_5555");
+    REQUIRE(client);
+    REQUIRE(server);
+
+    WHEN("requesting a ping reply") {
+      zq::proto::Ping ping;
+      ping.set_id(1);
+      ping.set_msg("Hi");
+      ;
+      auto tm = zq::typed_message("Hello world");
+      auto res = client->send(zq::typed_message(ping));
+      REQUIRE(res);
+
+      THEN("it's possible to receive and restore the message") {
+        auto request = server->await(await_time);
+        REQUIRE(request);
+        REQUIRE(request.value());
+        auto restored = zq::restore_as<zq::proto::Ping>(*request.value());
+        if (!restored) {
+          MESSAGE("error: ", restored.error().what());
+        }
+        REQUIRE(restored);
+        REQUIRE_EQ(restored->id(), 1);
+        REQUIRE_EQ(restored->msg(), "Hi");
+        AND_THEN("it's possible to send and receive a reply") {
+          zq::proto::Pong pong;
+          pong.set_id(1);
+          pong.set_reply("Hi there");
+          auto send_rc = server->send(zq::typed_message(pong));
+          REQUIRE(send_rc);
+          auto reply = client->await(await_time);
+          REQUIRE(reply);
+          REQUIRE(reply.value());
+          auto restored_reply = zq::restore_as<zq::proto::Pong>(*reply.value());
+          REQUIRE_EQ(restored_reply->id(), 1);
+          REQUIRE_EQ(restored_reply->reply(), "Hi there");
+        }
+      }
+    }
+  }
+}

--- a/tests/commu/typedmessage_proto_test.cpp
+++ b/tests/commu/typedmessage_proto_test.cpp
@@ -1,0 +1,27 @@
+#include <doctest/doctest.h>
+
+#include <zq/zq.hpp>
+#include "pingpong.pb.h"
+
+
+SCENARIO("Testing a protobuf based typed message") {
+  GIVEN("some Protobuf") {
+    zq::proto::Ping ping;
+    ping.set_id(23);
+    ping.set_msg("I am here");
+    ;
+    WHEN("creating a typed message") {
+      auto tm = zq::typed_message(ping);
+      THEN("the typed message can be restored as string") {
+        auto restored = zq::restore_as<zq::proto::Ping>(tm);
+        REQUIRE(restored);
+        REQUIRE_EQ(restored->id(), ping.id());
+        REQUIRE_EQ(restored->msg(), ping.msg());
+      }
+      AND_THEN("restoring to an other protobuf does not work") {
+        auto restored = zq::restore_as<zq::proto::Pong>(tm);
+        REQUIRE_FALSE(restored);
+      }
+    }
+  }
+}

--- a/tests/commu/typedmessage_test.cpp
+++ b/tests/commu/typedmessage_test.cpp
@@ -3,8 +3,6 @@
 #include <zq/message.hpp>
 #include <zq/zq.hpp>
 
-#include "pingpong.pb.h"
-
 SCENARIO("Testing an empty typed message") {
   GIVEN("an empty message") {
     zq::TypedMessage m;
@@ -67,28 +65,6 @@ SCENARIO("Testing double based typed message") {
       }
       AND_THEN("restoring to a float is not possible") {
         auto restored = zq::restore_as<float>(tm);
-        REQUIRE_FALSE(restored);
-      }
-    }
-  }
-}
-
-SCENARIO("Testing a protobuf based typed message") {
-  GIVEN("some Protobuf") {
-    zq::proto::Ping ping;
-    ping.set_id(23);
-    ping.set_msg("I am here");
-    ;
-    WHEN("creating a typed message") {
-      auto tm = zq::typed_message(ping);
-      THEN("the typed message can be restored as string") {
-        auto restored = zq::restore_as<zq::proto::Ping>(tm);
-        REQUIRE(restored);
-        REQUIRE_EQ(restored->id(), ping.id());
-        REQUIRE_EQ(restored->msg(), ping.msg());
-      }
-      AND_THEN("restoring to an other protobuf does not work") {
-        auto restored = zq::restore_as<zq::proto::Pong>(tm);
         REQUIRE_FALSE(restored);
       }
     }

--- a/tests/xtra/structs_test.cpp
+++ b/tests/xtra/structs_test.cpp
@@ -3,7 +3,6 @@
 // #include <zq/typename.hpp>
 #include <chrono>
 #include <thread>
-#include "pingpong.pb.h"
 
 namespace {
   // startup times on Windows are a problem, they take too long,


### PR DESCRIPTION
Not everyone using this zq wrapper want's to use protobuf
Therefore, make protobuf default optional

Per default, nothing should change but this PR will enables a
`cmake --preset ninja -D ZQ_WITH_PROTO=OFF`
build that doe not require protobof installed on the system
