### PR TITLE
Cmake config with dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ target_include_directories(zq INTERFACE
 if (ZQ_WITH_PROTO)
     find_package(Protobuf CONFIG REQUIRED)
     target_compile_definitions(zq INTERFACE "ZQ_PROTO")
+    set(Protobuf_DEPENDENCY "find_dependency(Protobuf)")
     add_subdirectory(proto)
 endif()
 

--- a/cmake/zqConfig.cmake.in
+++ b/cmake/zqConfig.cmake.in
@@ -2,6 +2,7 @@
 
 include("${CMAKE_CURRENT_LIST_DIR}/zqTargets.cmake")
 
+include(CMakeFindDependencyMacro)
 find_dependency(astr)
 find_dependency(Protobuf)
 find_dependency(tl-expected)

--- a/cmake/zqConfig.cmake.in
+++ b/cmake/zqConfig.cmake.in
@@ -2,4 +2,8 @@
 
 include("${CMAKE_CURRENT_LIST_DIR}/zqTargets.cmake")
 
+find_dependency(astr)
+find_dependency(Protobuf)
+find_dependency(tl-expected)
+
 check_required_components("zq")

--- a/cmake/zqConfig.cmake.in
+++ b/cmake/zqConfig.cmake.in
@@ -4,7 +4,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/zqTargets.cmake")
 
 include(CMakeFindDependencyMacro)
 find_dependency(astr)
-find_dependency(Protobuf)
+@Protobuf_DEPENDENCY@
 find_dependency(tl-expected)
 find_dependency(ZeroMQ)
 

--- a/cmake/zqConfig.cmake.in
+++ b/cmake/zqConfig.cmake.in
@@ -6,5 +6,6 @@ include(CMakeFindDependencyMacro)
 find_dependency(astr)
 find_dependency(Protobuf)
 find_dependency(tl-expected)
+find_dependency(ZeroMQ)
 
 check_required_components("zq")


### PR DESCRIPTION
At the moment, the users of the package need to manually import four additional dependencies before they can import `zq`. We can do it for them.